### PR TITLE
Release 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ The most common use case is sending one-off events from Android ViewModels to th
 With this library, there's no need for `SharedFlow`, `Channel`, or extra event-related 
 properties in your state classes.
 
-⚠️ This page covers the 2.x release, which is currently in alpha. 
-Looking for the stable 1.x version? Click [here](/docs/README_LEGACY_1x.md) to learn more.
+⚠️ This page covers the 2.x release. Looking for the 1.x version? Click [here](/docs/README_LEGACY_1x.md) to learn more.
 
 ℹ️ Migration guide from v1.x to v2.x is [here](#migration-from-version-1x-to-2x).
 
@@ -188,11 +187,11 @@ Installation steps may vary depending on the DI framework you're using.
 
    ```kotlin
    // annotation processor (required):
-   ksp("com.uandcode:effects2-hilt-compiler:2.0.0-alpha05")
+   ksp("com.uandcode:effects2-hilt-compiler:2.0.0")
    // for projects without Jetpack Compose:
-   implementation("com.uandcode:effects2-hilt:2.0.0-alpha05")
+   implementation("com.uandcode:effects2-hilt:2.0.0")
    // for projects with Jetpack Compose:
-   implementation("com.uandcode:effects2-hilt-compose:2.0.0-alpha05")
+   implementation("com.uandcode:effects2-hilt-compose:2.0.0")
    ```
 
 For more details, check out the [single-module Hilt example app](/app-examples/hilt/app-singlemodule).
@@ -205,11 +204,11 @@ For more details, check out the [single-module Hilt example app](/app-examples/h
 
    ```kotlin
    // annotation processor:
-   ksp("com.uandcode:effects2-koin-compiler:2.0.0-alpha05")
+   ksp("com.uandcode:effects2-koin-compiler:2.0.0")
    // for projects without Jetpack Compose:
-   implementation("com.uandcode:effects2-koin:2.0.0-alpha05")
+   implementation("com.uandcode:effects2-koin:2.0.0")
    // for projects with Jetpack Compose:
-   implementation("com.uandcode:effects2-koin-compose:2.0.0-alpha05")
+   implementation("com.uandcode:effects2-koin-compose:2.0.0")
    ```
 
 Check out [single-module Koin example app](/app-examples/koin/app-singlemodule) for more details.
@@ -225,11 +224,11 @@ Check out [single-module Koin example app](/app-examples/koin/app-singlemodule) 
 
    ```kotlin
    // annotation processor:
-   ksp("com.uandcode:effects2-core-compiler:2.0.0-alpha05")
+   ksp("com.uandcode:effects2-core-compiler:2.0.0")
    // for projects without Jetpack Compose:
-   implementation("com.uandcode:effects2-core-lifecycle:2.0.0-alpha05")
+   implementation("com.uandcode:effects2-core-lifecycle:2.0.0")
    // for projects with Jetpack Compose:
-   implementation("com.uandcode:effects2-core-compose:2.0.0-alpha05")
+   implementation("com.uandcode:effects2-core-compose:2.0.0")
    ```
 
 Check out [the single-module No-DI example app](/app-examples/core/app-singlemodule) for a working setup.
@@ -240,19 +239,19 @@ Check out [the single-module No-DI example app](/app-examples/core/app-singlemod
 
   ```kotlin
   // Hilt Integration:
-  ksp("com.uandcode:effects2-hilt-compiler:2.0.0-alpha05")
-  implementation("com.uandcode:effects2-hilt:2.0.0-alpha05") // without Jetpack Compose
-  implementation("com.uandcode:effects2-hilt-compose:2.0.0-alpha05") // with Jetpack Compose
+  ksp("com.uandcode:effects2-hilt-compiler:2.0.0")
+  implementation("com.uandcode:effects2-hilt:2.0.0") // without Jetpack Compose
+  implementation("com.uandcode:effects2-hilt-compose:2.0.0") // with Jetpack Compose
   
   // Koin Integration:
-  ksp("com.uandcode:effects2-koin-compiler:2.0.0-alpha05")
-  implementation("com.uandcode:effects2-koin:2.0.0-alpha05") // without Jetpack Compose
-  implementation("com.uandcode:effects2-koin-compose:2.0.0-alpha05") // with Jetpack Compose
+  ksp("com.uandcode:effects2-koin-compiler:2.0.0")
+  implementation("com.uandcode:effects2-koin:2.0.0") // without Jetpack Compose
+  implementation("com.uandcode:effects2-koin-compose:2.0.0") // with Jetpack Compose
   
   // No DI:
-  ksp("com.uandcode:effects2-core-compiler:2.0.0-alpha05")
-  implementation("com.uandcode:effects2-core-lifecycle:2.0.0-alpha05") // without Jetpack Compose
-  implementation("com.uandcode:effects2-core-compose:2.0.0-alpha05") // with Jetpack Compose
+  ksp("com.uandcode:effects2-core-compiler:2.0.0")
+  implementation("com.uandcode:effects2-core-lifecycle:2.0.0") // without Jetpack Compose
+  implementation("com.uandcode:effects2-core-compose:2.0.0") // with Jetpack Compose
   ```
 
 - Additional configuration is required for your __Library__ modules, if you
@@ -287,9 +286,9 @@ so this guide is relevant only for projects using Hilt.
 1. In your `build.gradle` file, update the library dependencies:
 
    ```kotlin
-   ksp("com.uandcode:effects2-hilt-compiler:2.0.0-alpha05")
-   implementation("com.uandcode:effects2-hilt:2.0.0-alpha05") // without Jetpack Compose
-   implementation("com.uandcode:effects2-hilt-compose:2.0.0-alpha05") // with Jetpack Compose
+   ksp("com.uandcode:effects2-hilt-compiler:2.0.0")
+   implementation("com.uandcode:effects2-hilt:2.0.0") // without Jetpack Compose
+   implementation("com.uandcode:effects2-hilt-compose:2.0.0") // with Jetpack Compose
    ```
 
 2. Update relevant import statements and package references:

--- a/docs/effects-and-hilt.md
+++ b/docs/effects-and-hilt.md
@@ -27,11 +27,11 @@ This page describes how to install and use the library with Hilt DI Framework.
 
    ```kotlin
    // annotation processor (required):
-   ksp("com.uandcode:effects2-hilt-compiler:2.0.0-alpha05")
+   ksp("com.uandcode:effects2-hilt-compiler:2.0.0")
    // for projects without Jetpack Compose:
-   implementation("com.uandcode:effects2-hilt:2.0.0-alpha05")
+   implementation("com.uandcode:effects2-hilt:2.0.0")
    // for projects with Jetpack Compose:
-   implementation("com.uandcode:effects2-hilt-compose:2.0.0-alpha05")
+   implementation("com.uandcode:effects2-hilt-compose:2.0.0")
    ```
 
 For more details, check out the [single-module Hilt example app](/app-examples/hilt/app-singlemodule).
@@ -41,9 +41,9 @@ For more details, check out the [single-module Hilt example app](/app-examples/h
 - Dependencies for your __application module__ remain the same:
 
   ```kotlin
-  ksp("com.uandcode:effects2-hilt-compiler:2.0.0-alpha05")
-  implementation("com.uandcode:effects2-hilt:2.0.0-alpha05") // without Jetpack Compose
-  implementation("com.uandcode:effects2-hilt-compose:2.0.0-alpha05") // with Jetpack Compose
+  ksp("com.uandcode:effects2-hilt-compiler:2.0.0")
+  implementation("com.uandcode:effects2-hilt:2.0.0") // without Jetpack Compose
+  implementation("com.uandcode:effects2-hilt-compose:2.0.0") // with Jetpack Compose
   ```
 
 - Additional configuration is required for your __Library__ modules, if you
@@ -72,9 +72,9 @@ and imports. Please make sure to update your project accordingly.
 1. In your `build.gradle` file, update the library dependencies:
 
    ```kotlin
-   ksp("com.uandcode:effects2-hilt-compiler:2.0.0-alpha05")
-   implementation("com.uandcode:effects2-hilt:2.0.0-alpha05") // without Jetpack Compose
-   implementation("com.uandcode:effects2-hilt-compose:2.0.0-alpha05") // with Jetpack Compose
+   ksp("com.uandcode:effects2-hilt-compiler:2.0.0")
+   implementation("com.uandcode:effects2-hilt:2.0.0") // without Jetpack Compose
+   implementation("com.uandcode:effects2-hilt-compose:2.0.0") // with Jetpack Compose
    ```
 
 2. Update relevant import statements and package references:

--- a/docs/effects-and-koin.md
+++ b/docs/effects-and-koin.md
@@ -31,11 +31,11 @@ This page explains how to install and use the library with the Koin DI Framework
 
    ```kotlin
    // annotation processor:
-   ksp("com.uandcode:effects2-koin-compiler:2.0.0-alpha05")
+   ksp("com.uandcode:effects2-koin-compiler:2.0.0")
    // for projects without Jetpack Compose:
-   implementation("com.uandcode:effects2-koin:2.0.0-alpha05")
+   implementation("com.uandcode:effects2-koin:2.0.0")
    // for projects with Jetpack Compose:
-   implementation("com.uandcode:effects2-koin-compose:2.0.0-alpha05")
+   implementation("com.uandcode:effects2-koin-compose:2.0.0")
    
    // Koin dependencies
    implementation("io.insert-koin:koin-android:4.0.3")
@@ -50,9 +50,9 @@ For more details, check out the [single-module Koin example app](/app-examples/k
 - Dependencies for your __application module__ remain the same:
 
   ```kotlin
-  ksp("com.uandcode:effects2-koin-compiler:2.0.0-alpha05")
-  implementation("com.uandcode:effects2-koin:2.0.0-alpha05") // without Jetpack Compose
-  implementation("com.uandcode:effects2-koin-compose:2.0.0-alpha05") // with Jetpack Compose
+  ksp("com.uandcode:effects2-koin-compiler:2.0.0")
+  implementation("com.uandcode:effects2-koin:2.0.0") // without Jetpack Compose
+  implementation("com.uandcode:effects2-koin-compose:2.0.0") // with Jetpack Compose
   ```
 
 - Additional configuration is required for your __Library__ modules, if you

--- a/docs/effects-pure.md
+++ b/docs/effects-pure.md
@@ -28,11 +28,11 @@ Add the necessary dependencies:
 
 ```kotlin
 // annotation processor:
-ksp("com.uandcode:effects2-core-compiler:2.0.0-alpha05")
+ksp("com.uandcode:effects2-core-compiler:2.0.0")
 // for projects without Jetpack Compose:
-implementation("com.uandcode:effects2-core-lifecycle:2.0.0-alpha05")
+implementation("com.uandcode:effects2-core-lifecycle:2.0.0")
 // for projects with Jetpack Compose:
-implementation("com.uandcode:effects2-core-compose:2.0.0-alpha05")
+implementation("com.uandcode:effects2-core-compose:2.0.0")
 ```
 
 Check out [the single-module No-DI example app](/app-examples/core/app-singlemodule) for a working setup.
@@ -42,9 +42,9 @@ Check out [the single-module No-DI example app](/app-examples/core/app-singlemod
 - Dependencies for your __application module__ remain the same:
 
   ```kotlin
-  ksp("com.uandcode:effects2-core-compiler:2.0.0-alpha05")
-  implementation("com.uandcode:effects2-core-lifecycle:2.0.0-alpha05") // without Jetpack Compose
-  implementation("com.uandcode:effects2-core-compose:2.0.0-alpha05") // with Jetpack Compose
+  ksp("com.uandcode:effects2-core-compiler:2.0.0")
+  implementation("com.uandcode:effects2-core-lifecycle:2.0.0") // without Jetpack Compose
+  implementation("com.uandcode:effects2-core-compose:2.0.0") // with Jetpack Compose
   ```
 
 - Additional configuration is required for your __Library__ modules, if you

--- a/docs/ksp-and-koin-installation.md
+++ b/docs/ksp-and-koin-installation.md
@@ -57,6 +57,6 @@ even [without KSP](no-ksp-installation.md), with a bit of additional configurati
    dependencies {
        // KSP annotation processors should be added using the 'ksp' configuration
        // Example: adding Effect's KSP compiler
-       // ksp("com.uandcode:effects2-koin-compiler:2.0.0-alpha05")
+       // ksp("com.uandcode:effects2-koin-compiler:2.0.0")
    }
    ```

--- a/docs/no-ksp-installation.md
+++ b/docs/no-ksp-installation.md
@@ -40,11 +40,11 @@ You can skip KSP if:
 
    ```kotlin
    // required:
-   implementation("com.uandcode:effects2-core-runtime:2.0.0-alpha05")
+   implementation("com.uandcode:effects2-core-runtime:2.0.0")
    // for projects without Jetpack Compose:
-   implementation("com.uandcode:effects2-koin:2.0.0-alpha05")
+   implementation("com.uandcode:effects2-koin:2.0.0")
    // for projects with Jetpack Compose:
-   implementation("com.uandcode:effects2-koin-compose:2.0.0-alpha05")
+   implementation("com.uandcode:effects2-koin-compose:2.0.0")
    
    // Koin dependencies:
    implementation("io.insert-koin:koin-core:4.0.3") // core
@@ -174,11 +174,11 @@ You can skip KSP if:
 
    ```kotlin
    // required:
-   implementation("com.uandcode:effects2-core-runtime:2.0.0-alpha05")
+   implementation("com.uandcode:effects2-core-runtime:2.0.0")
    // for projects without Jetpack Compose:
-   implementation("com.uandcode:effects2-core-lifecycle:2.0.0-alpha05")
+   implementation("com.uandcode:effects2-core-lifecycle:2.0.0")
    // for projects with Jetpack Compose:
-   implementation("com.uandcode:effects2-core-compose:2.0.0-alpha05")   
+   implementation("com.uandcode:effects2-core-compose:2.0.0")   
    ```
 
 2. Create a custom Application class and call `setupRuntimeEffectsGlobally()`

--- a/effects-core/essentials/src/main/java/com/uandcode/effects/core/RootEffectScopes.kt
+++ b/effects-core/essentials/src/main/java/com/uandcode/effects/core/RootEffectScopes.kt
@@ -1,6 +1,8 @@
 package com.uandcode.effects.core
 
-import com.uandcode.effects.core.internal.scopes.EmptyEffectScope
+import com.uandcode.effects.core.factories.DefaultProxyEffectFactory
+import com.uandcode.effects.core.factories.ProxyEffectFactory
+import com.uandcode.effects.core.internal.scopes.buildEmptyEffectScope
 import com.uandcode.effects.core.internal.scopes.buildGlobalEffectScope
 
 /**
@@ -19,12 +21,24 @@ public object RootEffectScopes {
      * This is an empty effect scope that can be used to create your
      * own hierarchy of scopes.
      */
-    public val empty: EffectScope = EmptyEffectScope
+    public val empty: EffectScope by lazy {
+        buildEmptyEffectScope(DefaultProxyEffectFactory())
+    }
 
     /**
      * Global singleton scope containing references to all annotated effects.
      */
     public val global: EffectScope get() = _global
+
+    /**
+     * Create an empty effect scope that can be used to create your
+     * own hierarchy of scopes.
+     */
+    public fun empty(
+        proxyEffectFactory: ProxyEffectFactory = DefaultProxyEffectFactory()
+    ): EffectScope {
+        return buildEmptyEffectScope(proxyEffectFactory)
+    }
 
     /**
      * Set a custom [EffectScope] instance which will be used

--- a/effects-core/essentials/src/main/java/com/uandcode/effects/core/internal/scopes/EmptyEffectScope.kt
+++ b/effects-core/essentials/src/main/java/com/uandcode/effects/core/internal/scopes/EmptyEffectScope.kt
@@ -1,17 +1,17 @@
 package com.uandcode.effects.core.internal.scopes
 
 import com.uandcode.effects.core.EffectScope
-import com.uandcode.effects.core.factories.DefaultProxyEffectFactory
 import com.uandcode.effects.core.ManagedInterfaces
+import com.uandcode.effects.core.factories.ProxyEffectFactory
 
-internal val EmptyEffectScope: EffectScope = LazyEffectScope {
-    buildEmptyEffectScope()
-}
-
-internal fun buildEmptyEffectScope(): EffectScope {
-    return DefaultEffectScope(
-        managedInterfaces = ManagedInterfaces.ListOf(),
-        proxyEffectFactory = DefaultProxyEffectFactory(),
-        parent = null,
-    )
+internal fun buildEmptyEffectScope(
+    proxyEffectFactory: ProxyEffectFactory
+): EffectScope {
+    return LazyEffectScope {
+        DefaultEffectScope(
+            managedInterfaces = ManagedInterfaces.ListOf(),
+            proxyEffectFactory = proxyEffectFactory,
+            parent = null,
+        )
+    }
 }

--- a/effects-core/essentials/src/test/java/com/uandcode/effects/core/RootEffectScopesTest.kt
+++ b/effects-core/essentials/src/test/java/com/uandcode/effects/core/RootEffectScopesTest.kt
@@ -1,6 +1,5 @@
 package com.uandcode.effects.core
 
-import com.uandcode.effects.core.internal.scopes.EmptyEffectScope
 import com.uandcode.effects.core.internal.scopes.buildGlobalEffectScope
 import io.mockk.MockKAnnotations
 import io.mockk.clearAllMocks
@@ -27,11 +26,6 @@ class RootEffectScopesTest {
     @After
     fun tearDown() {
         clearAllMocks()
-    }
-
-    @Test
-    fun `test default empty scope`() {
-        assertEquals(EmptyEffectScope, RootEffectScopes.empty)
     }
 
     @Test

--- a/effects-core/runtime/src/main/java/com/uandcode/effects/core/runtime/GlobalRuntimeEffectSetup.kt
+++ b/effects-core/runtime/src/main/java/com/uandcode/effects/core/runtime/GlobalRuntimeEffectSetup.kt
@@ -21,9 +21,6 @@ import com.uandcode.effects.core.RootEffectScopes
  * ```
  */
 public fun setupRuntimeEffectsGlobally() {
-    val runtimeGlobalScope = RootEffectScopes.empty.createChild(
-        managedInterfaces = ManagedInterfaces.Everything,
-        proxyEffectFactory = RuntimeProxyEffectFactory()
-    )
+    val runtimeGlobalScope = RuntimeEffectScopes.createGlobal()
     RootEffectScopes.setGlobal(runtimeGlobalScope)
 }

--- a/effects-core/runtime/src/main/java/com/uandcode/effects/core/runtime/RuntimeEffectScopes.kt
+++ b/effects-core/runtime/src/main/java/com/uandcode/effects/core/runtime/RuntimeEffectScopes.kt
@@ -6,6 +6,10 @@ import com.uandcode.effects.core.RootEffectScopes
 
 public object RuntimeEffectScopes {
 
+    public fun createEmpty(): EffectScope {
+        return RootEffectScopes.empty(RuntimeProxyEffectFactory())
+    }
+
     /**
      * Create a new [EffectScope] which can create proxy implementations
      * for all effect [managedInterfaces] at runtime.
@@ -17,30 +21,13 @@ public object RuntimeEffectScopes {
      *
      * ```
      * // replace a root effect scope with a runtime one
-     * RootEffectScopes.setGlobal(RuntimeEffectScopes.create())
+     * RootEffectScopes.setGlobal(RuntimeEffectScopes.createGlobal())
      * ```
      */
-    public fun create(
+    public fun createGlobal(
         managedInterfaces: ManagedInterfaces = ManagedInterfaces.Everything
     ): EffectScope {
-        return RootEffectScopes.empty.createChild(
-            managedInterfaces = managedInterfaces,
-            proxyEffectFactory = RuntimeProxyEffectFactory()
-        )
-    }
-
-    /**
-     * Create a child [EffectScope] which can create proxy implementations
-     * for all [managedInterfaces] at runtime.
-     */
-    public fun createChild(
-        parent: EffectScope,
-        managedInterfaces: ManagedInterfaces = ManagedInterfaces.Everything
-    ): EffectScope {
-        return parent.createChild(
-            managedInterfaces = managedInterfaces,
-            proxyEffectFactory = RuntimeProxyEffectFactory()
-        )
+        return createEmpty().createChild(managedInterfaces)
     }
 
 }

--- a/effects-core/runtime/src/test/java/com/uandcode/effects/core/runtime/CoreRuntimeIntegrationTest.kt
+++ b/effects-core/runtime/src/test/java/com/uandcode/effects/core/runtime/CoreRuntimeIntegrationTest.kt
@@ -52,8 +52,7 @@ class CoreRuntimeIntegrationTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
-        RootEffectScopes.setGlobal(RuntimeEffectScopes.create())
-        scope = RootEffectScopes.global
+        scope = RuntimeEffectScopes.createGlobal()
     }
 
     @After

--- a/effects-koin/essentials/build.gradle.kts
+++ b/effects-koin/essentials/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     api(projects.effectsKoin.annotations)
     compileOnly(projects.effectsKoin.kspcontract)
     testImplementation(projects.effectsKoin.kspcontract)
+    testImplementation(projects.effectsCore.testing.lifecycle)
 
     implementation(platform(libs.koin.bom))
     implementation(libs.koin.core)

--- a/effects-koin/essentials/build.gradle.kts
+++ b/effects-koin/essentials/build.gradle.kts
@@ -14,8 +14,12 @@ dependencies {
     api(projects.effectsCore.runtime)
     api(projects.effectsKoin.annotations)
     compileOnly(projects.effectsKoin.kspcontract)
+    testImplementation(projects.effectsKoin.kspcontract)
 
     implementation(platform(libs.koin.bom))
     implementation(libs.koin.core)
     implementation(libs.koin.viewmodel)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
 }

--- a/effects-koin/essentials/src/main/java/com/uandcode/effects/koin/internal/ConstructorArg.kt
+++ b/effects-koin/essentials/src/main/java/com/uandcode/effects/koin/internal/ConstructorArg.kt
@@ -12,6 +12,7 @@ internal class ConstructorArg : AutoCloseable {
 
     override fun close() {
         closeable?.close()
+        closeable = null
     }
 
 }

--- a/effects-koin/essentials/src/main/java/com/uandcode/effects/koin/internal/ConstructorArgStack.kt
+++ b/effects-koin/essentials/src/main/java/com/uandcode/effects/koin/internal/ConstructorArgStack.kt
@@ -17,8 +17,8 @@ internal class ConstructorArgStack {
         args.clear()
     }
 
-    fun pop() {
-        args.removeLastOrNull()
+    fun pop(): ConstructorArg? {
+        return args.removeLastOrNull()
     }
 
     fun popTo(arg: ConstructorArg): List<ConstructorArg> {

--- a/effects-koin/essentials/src/main/java/com/uandcode/effects/koin/internal/EffectScopeValidator.kt
+++ b/effects-koin/essentials/src/main/java/com/uandcode/effects/koin/internal/EffectScopeValidator.kt
@@ -22,7 +22,7 @@ internal fun Module.validateEffectScopeQualifier(qualifier: Qualifier, id: Int) 
         createdAtStart = true,
         qualifier = named("effectScope-$qualifier-$id")
     ) {
-        get<EffectScopeValidator>().add(qualifier)
+        get<EffectScopeValidator>().apply { add(qualifier) }
     }
 }
 

--- a/effects-koin/essentials/src/main/java/com/uandcode/effects/koin/internal/InstanceFactoryInterceptor.kt
+++ b/effects-koin/essentials/src/main/java/com/uandcode/effects/koin/internal/InstanceFactoryInterceptor.kt
@@ -91,8 +91,9 @@ internal class InstanceFactoryInterceptor<T>(
 
 }
 
-internal fun KoinApplication.overrideInstances() {
-    val constructorArgStack = ConstructorArgStack()
+internal fun KoinApplication.overrideInstances(
+    constructorArgStack: ConstructorArgStack = ConstructorArgStack()
+) {
     val allInstances = koin.instanceRegistry.instances as MutableMap
     allInstances.keys.toList().forEach { key ->
         allInstances[key]?.let { instanceFactory ->

--- a/effects-koin/essentials/src/main/java/com/uandcode/effects/koin/internal/InternalKoinEffectScopes.kt
+++ b/effects-koin/essentials/src/main/java/com/uandcode/effects/koin/internal/InternalKoinEffectScopes.kt
@@ -19,12 +19,14 @@ internal data class LocalEffectQualifier(val value: String)
  * For internal usage. Public modifier is added to make this function available
  * from auto-generated code.
  */
-public fun Module.internalSetupRootEffects() {
+public fun Module.internalSetupRootEffects(
+    rootEffectScope: EffectScope = RootEffectScopes.global
+) {
     single<LocalEffectQualifier> {
         LocalEffectQualifier(KOIN_EFFECT_ROOT_QUALIFIER.value)
     }
     single(KOIN_EFFECT_ROOT_QUALIFIER) {
-        RootEffectScopes.global
+        rootEffectScope
     }
     factory<EffectScope> {
         get(KOIN_EFFECT_ROOT_QUALIFIER)
@@ -58,10 +60,12 @@ public fun ScopeDSL.internalSetupScopedEffects(
     }
 }
 
-internal fun KoinApplication.installRootEffects() {
+internal fun KoinApplication.installRootEffects(
+    rootEffectScope: EffectScope = RootEffectScopes.global
+) {
     modules(
         module {
-            internalSetupRootEffects()
+            internalSetupRootEffects(rootEffectScope)
         }
     )
 }

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/KoinEffectDeclarationsTest.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/KoinEffectDeclarationsTest.kt
@@ -1,0 +1,61 @@
+package com.uandcode.effects.koin
+
+import com.uandcode.effects.core.EffectScope
+import com.uandcode.effects.core.getProxy
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+
+class KoinEffectDeclarationsTest {
+
+    @Test
+    fun `Module effect() registers factory`() {
+        val effectScope = mockk<EffectScope>()
+        val expectedEffect1 = mockk<Effect>()
+        val expectedEffect2 = mockk<Effect>()
+        every { effectScope.getProxy<Effect>() } returns expectedEffect1 andThen expectedEffect2
+        val module = module {
+            factory<EffectScope> { effectScope }
+            effect<Effect>()
+        }
+        val koin = koinApplication {
+            modules(module)
+        }.koin
+
+        val effect1 = koin.get<Effect>()
+        val effect2 = koin.get<Effect>()
+
+        assertSame(expectedEffect1, effect1)
+        assertSame(expectedEffect2, effect2)
+    }
+
+    @Test
+    fun `ScopeDSL effect() registers factory`() {
+        val effectScope = mockk<EffectScope>()
+        val expectedEffect1 = mockk<Effect>()
+        val expectedEffect2 = mockk<Effect>()
+        every { effectScope.getProxy<Effect>() } returns expectedEffect1 andThen expectedEffect2
+        val module = module {
+            factory<EffectScope> { effectScope }
+            scope<MyScope> {
+                effect<Effect>()
+            }
+        }
+        val koin = koinApplication {
+            modules(module)
+        }.koin
+        val scope = koin.createScope<MyScope>()
+
+        val effect1 = scope.get<Effect>()
+        val effect2 = scope.get<Effect>()
+
+        assertSame(expectedEffect1, effect1)
+        assertSame(expectedEffect2, effect2)
+    }
+
+    private interface Effect
+    private class MyScope
+}

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/KoinEffectScopeBuilderTest.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/KoinEffectScopeBuilderTest.kt
@@ -1,0 +1,57 @@
+@file:OptIn(KoinInternalApi::class)
+
+package com.uandcode.effects.koin
+
+import com.uandcode.effects.core.EffectScope
+import com.uandcode.effects.core.getProxy
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.dsl.ScopeDSL
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+
+class KoinEffectScopeBuilderTest {
+
+    @MockK
+    private lateinit var scopeDSL: ScopeDSL
+
+    private lateinit var builder: KoinEffectScopeBuilder
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        builder = KoinEffectScopeBuilder(scopeDSL)
+    }
+
+    @Test
+    fun `effect() registers effect and scopes it`() {
+        val effectScope = mockk<EffectScope>()
+        val expectedEffect = mockk<Effect>()
+        every { effectScope.getProxy<Effect>() } returns expectedEffect
+        val module = module {
+            scope<MyScope> {
+                scoped { effectScope }
+                builder = KoinEffectScopeBuilder(this)
+                builder.effect<Effect>()
+            }
+        }
+        val koin = koinApplication {
+            modules(module)
+        }.koin
+
+        val effect = koin.createScope<MyScope>().get<Effect>()
+
+        assertTrue(builder.registeredEffects.contains(Effect::class))
+        assertSame(expectedEffect, effect)
+    }
+
+    private interface Effect
+    private class MyScope
+}

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/controller/AndroidScopeComponentExtensionsTest.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/controller/AndroidScopeComponentExtensionsTest.kt
@@ -1,0 +1,70 @@
+package com.uandcode.effects.koin.controller
+
+import com.uandcode.effects.core.EffectController
+import com.uandcode.effects.core.EffectScope
+import com.uandcode.effects.core.getController
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.koin.android.scope.AndroidScopeComponent
+import org.koin.core.scope.Scope
+
+class AndroidScopeComponentExtensionsTest {
+
+    @MockK
+    private lateinit var effectScope: EffectScope
+
+    @MockK
+    private lateinit var scope: Scope
+
+    @MockK
+    private lateinit var scopeComponent: AndroidScopeComponent
+
+    @MockK
+    private lateinit var expectedController: EffectController<Effect>
+
+    private lateinit var expectedEffectImpl: EffectImpl
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        expectedEffectImpl = EffectImpl()
+        every { scopeComponent.scope } returns scope
+        every { scope.get<EffectScope>() } returns effectScope
+        every { effectScope.getController<Effect>() } returns expectedController
+        every { expectedController.isStarted } returns false
+    }
+
+    @Test
+    fun `test getEffectController`() {
+        val controller = scopeComponent.getEffectController<Effect>()
+        assertSame(expectedController, controller)
+    }
+
+    @Test
+    fun `test injectEffectController`() {
+        val lazy = scopeComponent.injectEffectController<Effect>()
+        val controller = lazy.value
+        assertSame(expectedController, controller)
+    }
+
+    @Test
+    fun `test getBoundEffectController`() {
+        val boundController = scopeComponent.getBoundEffectController<Effect> { expectedEffectImpl }
+        assertSame(expectedEffectImpl, boundController.effectImplementation)
+    }
+
+    @Test
+    fun `test injectBoundEffectController`() {
+        val lazy = scopeComponent.injectBoundEffectController<Effect> { expectedEffectImpl }
+        val boundController = lazy.value
+        assertSame(expectedEffectImpl, boundController.effectImplementation)
+    }
+
+    private interface Effect
+    private class EffectImpl : Effect
+
+}

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/controller/KoinComponentExtensionsTest.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/controller/KoinComponentExtensionsTest.kt
@@ -1,0 +1,66 @@
+package com.uandcode.effects.koin.controller
+
+import com.uandcode.effects.core.EffectController
+import com.uandcode.effects.core.EffectScope
+import com.uandcode.effects.core.getController
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+
+class KoinComponentExtensionsTest {
+
+    @MockK
+    private lateinit var effectScope: EffectScope
+
+    @MockK
+    private lateinit var koinComponent: KoinComponent
+
+    @MockK
+    private lateinit var expectedController: EffectController<Effect>
+
+    private lateinit var expectedEffectImpl: EffectImpl
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        expectedEffectImpl = EffectImpl()
+        every { koinComponent.get<EffectScope>() } returns effectScope
+        every { effectScope.getController<Effect>() } returns expectedController
+        every { expectedController.isStarted } returns false
+    }
+
+    @Test
+    fun `test getEffectController`() {
+        val controller = koinComponent.getEffectController<Effect>()
+        assertSame(expectedController, controller)
+    }
+
+    @Test
+    fun `test injectEffectController`() {
+        val lazy = koinComponent.injectEffectController<Effect>()
+        val controller = lazy.value
+        assertSame(expectedController, controller)
+    }
+
+    @Test
+    fun `test getBoundEffectController`() {
+        val boundController = koinComponent.getBoundEffectController<Effect> { expectedEffectImpl }
+        assertSame(expectedEffectImpl, boundController.effectImplementation)
+    }
+
+    @Test
+    fun `test injectBoundEffectController`() {
+        val lazy = koinComponent.injectBoundEffectController<Effect> { expectedEffectImpl }
+        val boundController = lazy.value
+        assertSame(expectedEffectImpl, boundController.effectImplementation)
+    }
+
+    private interface Effect
+    private class EffectImpl : Effect
+
+}

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/controller/KoinExtensionsTest.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/controller/KoinExtensionsTest.kt
@@ -1,0 +1,64 @@
+package com.uandcode.effects.koin.controller
+
+import com.uandcode.effects.core.EffectController
+import com.uandcode.effects.core.EffectScope
+import com.uandcode.effects.core.getController
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.koin.core.Koin
+
+class KoinExtensionsTest {
+    @MockK
+    private lateinit var effectScope: EffectScope
+
+    @MockK
+    private lateinit var koin: Koin
+
+    @MockK
+    private lateinit var expectedController: EffectController<Effect>
+
+    private lateinit var expectedEffectImpl: EffectImpl
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        expectedEffectImpl = EffectImpl()
+        every { koin.get<EffectScope>() } returns effectScope
+        every { effectScope.getController<Effect>() } returns expectedController
+        every { expectedController.isStarted } returns false
+    }
+
+    @Test
+    fun `test getEffectController`() {
+        val controller = koin.getEffectController<Effect>()
+        assertSame(expectedController, controller)
+    }
+
+    @Test
+    fun `test injectEffectController`() {
+        val lazy = koin.injectEffectController<Effect>()
+        val controller = lazy.value
+        assertSame(expectedController, controller)
+    }
+
+    @Test
+    fun `test getBoundEffectController`() {
+        val boundController = koin.getBoundEffectController<Effect> { expectedEffectImpl }
+        assertSame(expectedEffectImpl, boundController.effectImplementation)
+    }
+
+    @Test
+    fun `test injectBoundEffectController`() {
+        val lazy = koin.injectBoundEffectController<Effect> { expectedEffectImpl }
+        val boundController = lazy.value
+        assertSame(expectedEffectImpl, boundController.effectImplementation)
+    }
+
+    private interface Effect
+    private class EffectImpl : Effect
+
+}

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/controller/KoinScopeComponentExtensionsTest.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/controller/KoinScopeComponentExtensionsTest.kt
@@ -1,0 +1,70 @@
+package com.uandcode.effects.koin.controller
+
+import com.uandcode.effects.core.EffectController
+import com.uandcode.effects.core.EffectScope
+import com.uandcode.effects.core.getController
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.koin.core.component.KoinScopeComponent
+import org.koin.core.scope.Scope
+
+class KoinScopeComponentExtensionsTest {
+
+    @MockK
+    private lateinit var effectScope: EffectScope
+
+    @MockK
+    private lateinit var scope: Scope
+
+    @MockK
+    private lateinit var scopeComponent: KoinScopeComponent
+
+    @MockK
+    private lateinit var expectedController: EffectController<Effect>
+
+    private lateinit var expectedEffectImpl: EffectImpl
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        expectedEffectImpl = EffectImpl()
+        every { scopeComponent.scope } returns scope
+        every { scope.get<EffectScope>() } returns effectScope
+        every { effectScope.getController<Effect>() } returns expectedController
+        every { expectedController.isStarted } returns false
+    }
+
+    @Test
+    fun `test getEffectController`() {
+        val controller = scopeComponent.getEffectController<Effect>()
+        assertSame(expectedController, controller)
+    }
+
+    @Test
+    fun `test injectEffectController`() {
+        val lazy = scopeComponent.injectEffectController<Effect>()
+        val controller = lazy.value
+        assertSame(expectedController, controller)
+    }
+
+    @Test
+    fun `test getBoundEffectController`() {
+        val boundController = scopeComponent.getBoundEffectController<Effect> { expectedEffectImpl }
+        assertSame(expectedEffectImpl, boundController.effectImplementation)
+    }
+
+    @Test
+    fun `test injectBoundEffectController`() {
+        val lazy = scopeComponent.injectBoundEffectController<Effect> { expectedEffectImpl }
+        val boundController = lazy.value
+        assertSame(expectedEffectImpl, boundController.effectImplementation)
+    }
+
+    private interface Effect
+    private class EffectImpl : Effect
+
+}

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/controller/ScopeExtensionsTest.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/controller/ScopeExtensionsTest.kt
@@ -1,0 +1,65 @@
+package com.uandcode.effects.koin.controller
+
+import com.uandcode.effects.core.EffectController
+import com.uandcode.effects.core.EffectScope
+import com.uandcode.effects.core.getController
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.koin.core.scope.Scope
+
+class ScopeExtensionsTest {
+
+    @MockK
+    private lateinit var effectScope: EffectScope
+
+    @MockK
+    private lateinit var scope: Scope
+
+    @MockK
+    private lateinit var expectedController: EffectController<Effect>
+
+    private lateinit var expectedEffectImpl: EffectImpl
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        expectedEffectImpl = EffectImpl()
+        every { scope.get<EffectScope>() } returns effectScope
+        every { effectScope.getController<Effect>() } returns expectedController
+        every { expectedController.isStarted } returns false
+    }
+
+    @Test
+    fun `test getEffectController`() {
+        val controller = scope.getEffectController<Effect>()
+        assertSame(expectedController, controller)
+    }
+
+    @Test
+    fun `test injectEffectController`() {
+        val lazy = scope.injectEffectController<Effect>()
+        val controller = lazy.value
+        assertSame(expectedController, controller)
+    }
+
+    @Test
+    fun `test getBoundEffectController`() {
+        val boundController = scope.getBoundEffectController<Effect> { expectedEffectImpl }
+        assertSame(expectedEffectImpl, boundController.effectImplementation)
+    }
+
+    @Test
+    fun `test injectBoundEffectController`() {
+        val lazy = scope.injectBoundEffectController<Effect> { expectedEffectImpl }
+        val boundController = lazy.value
+        assertSame(expectedEffectImpl, boundController.effectImplementation)
+    }
+
+    private interface Effect
+    private class EffectImpl : Effect
+
+}

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/internal/ConstructorArgStackTest.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/internal/ConstructorArgStackTest.kt
@@ -1,0 +1,180 @@
+package com.uandcode.effects.koin.internal
+
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+
+class ConstructorArgStackTest {
+
+    private lateinit var stack: ConstructorArgStack
+
+    @Before
+    fun setUp() {
+        stack = ConstructorArgStack()
+    }
+
+    @Test
+    fun `push() adds new element`() {
+        val arg = ConstructorArg()
+
+        stack.push(arg)
+
+        assertSame(arg, stack.peek())
+    }
+
+    @Test
+    fun `peek() returns latest element`() {
+        val arg = ConstructorArg()
+
+        stack.push(ConstructorArg())
+        stack.push(ConstructorArg())
+        stack.push(arg)
+
+        assertSame(arg, stack.peek())
+    }
+
+    @Test
+    fun `peek() does not remove latest element from stack`() {
+        val arg = ConstructorArg()
+
+        stack.push(ConstructorArg())
+        stack.push(arg)
+
+        assertSame(arg, stack.peek())
+        assertSame(arg, stack.peek())
+    }
+
+    @Test
+    fun `pop() returns latest element and removes it from stack`() {
+        val arg1 = ConstructorArg()
+        val arg2 = ConstructorArg()
+
+        stack.push(arg1)
+        stack.push(arg2)
+
+        assertSame(arg2, stack.pop())
+        assertSame(arg1, stack.pop())
+        assertNull(stack.pop())
+    }
+
+    @Test
+    fun `clear() removes all elements from stack`() {
+        stack.push(ConstructorArg())
+        stack.push(ConstructorArg())
+
+        stack.clear()
+
+        assertNull(stack.peek())
+        assertEquals(0, stack.count())
+    }
+
+    @Test
+    fun `popTo() removes latest elements up to specified element`() {
+        val arg1 = createArg()
+        val arg2 = createArg()
+        val arg3 = createArg()
+        val arg4 = createArg()
+        val arg5 = createArg()
+        stack.push(arg1)
+        stack.push(arg2)
+        stack.push(arg3)
+        stack.push(arg4)
+        stack.push(arg5)
+
+        val args = stack.popTo(arg2)
+
+        assertEquals(
+            listOf(arg3, arg4, arg5),
+            args
+        )
+        assertEquals(2, stack.count())
+        assertEquals(arg2, stack.peek())
+    }
+
+    @Test
+    fun `popTo() with specified latest element  returns empty list`() {
+        val arg1 = createArg()
+        val arg2 = createArg()
+        val arg3 = createArg()
+        stack.push(arg1)
+        stack.push(arg2)
+        stack.push(arg3)
+
+        val args = stack.popTo(arg3)
+
+        assertEquals(emptyList<ConstructorArg>(), args)
+        assertEquals(3, stack.count())
+        assertEquals(arg3, stack.peek())
+    }
+
+    @Test
+    fun `popTo() with unknown specified element returns empty list`() {
+        val arg1 = createArg()
+        val arg2 = createArg()
+        val arg3 = createArg()
+        stack.push(arg1)
+        stack.push(arg2)
+        stack.push(arg3)
+
+        val args = stack.popTo(ConstructorArg())
+
+        assertEquals(emptyList<ConstructorArg>(), args)
+        assertEquals(3, stack.count())
+        assertEquals(arg3, stack.peek())
+    }
+
+    @Test
+    fun `popTo() does not return items without assigned closeables`() {
+        val arg1 = ConstructorArg()
+        val arg2 = ConstructorArg()
+        val arg3 = ConstructorArg().apply { assignCloseable(mockk()) }
+        val arg4 = ConstructorArg()
+        val arg5 = ConstructorArg().apply { assignCloseable(mockk()) }
+        stack.push(arg1)
+        stack.push(arg2)
+        stack.push(arg3)
+        stack.push(arg4)
+        stack.push(arg5)
+
+        val args = stack.popTo(arg2)
+
+        assertEquals(listOf(arg3, arg5), args)
+        assertEquals(2, stack.count())
+        assertEquals(arg2, stack.peek())
+    }
+
+    @Test
+    fun `popTo() with specified first item returns all items except first one`() {
+        val arg1 = createArg()
+        val arg2 = createArg()
+        val arg3 = createArg()
+        stack.push(arg1)
+        stack.push(arg2)
+        stack.push(arg3)
+
+        val args = stack.popTo(arg1)
+
+        assertEquals(listOf(arg2, arg3), args)
+        assertEquals(1, stack.count())
+        assertEquals(arg1, stack.peek())
+    }
+
+    @Test
+    fun `count() returns current count of elements`() {
+        assertEquals(0, stack.count())
+
+        stack.push(ConstructorArg())
+        stack.push(ConstructorArg())
+        assertEquals(2, stack.count())
+
+        stack.pop()
+        assertEquals(1, stack.count())
+    }
+
+    private fun createArg() = ConstructorArg().apply {
+        assignCloseable(mockk())
+    }
+}

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/internal/ConstructorArgTest.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/internal/ConstructorArgTest.kt
@@ -1,0 +1,61 @@
+package com.uandcode.effects.koin.internal
+
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.Test.None
+
+class ConstructorArgTest {
+
+    private lateinit var constructorArg: ConstructorArg
+
+    @Before
+    fun setUp() {
+        constructorArg = ConstructorArg()
+    }
+
+    @Test
+    fun `hasCloseable() without assigned closeable returns false`() {
+        assertFalse(constructorArg.hasCloseable())
+    }
+
+    @Test
+    fun `hasCloseable() with assigned closeable returns true`() {
+        constructorArg.assignCloseable(mockk())
+        assertTrue(constructorArg.hasCloseable())
+    }
+
+    @Test(expected = None::class)
+    fun `close() without assigned closeable does not fail`() {
+        constructorArg.close()
+    }
+
+    @Test
+    fun `close() with assigned closeable closes it`() {
+        val closeable = mockk<AutoCloseable>(relaxUnitFun = true)
+        constructorArg.assignCloseable(closeable)
+
+        constructorArg.close()
+
+        verify(exactly = 1) {
+            closeable.close()
+        }
+    }
+
+    @Test
+    fun `close() with assigned closeable closes it once`() {
+        val closeable = mockk<AutoCloseable>(relaxUnitFun = true)
+        constructorArg.assignCloseable(closeable)
+
+        constructorArg.close()
+        constructorArg.close()
+
+        verify(exactly = 1) {
+            closeable.close()
+        }
+    }
+
+}

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/internal/EffectScopeClassValidatorTest.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/internal/EffectScopeClassValidatorTest.kt
@@ -1,0 +1,95 @@
+package com.uandcode.effects.koin.internal
+
+import com.uandcode.effects.koin.exceptions.DuplicateEffectScopeException
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.Test.None
+import org.koin.core.qualifier.StringQualifier
+import org.koin.core.qualifier.named
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+
+class EffectScopeClassValidatorTest {
+
+    private lateinit var validator: EffectScopeValidator
+
+    @Before
+    fun setUp() {
+        validator = EffectScopeValidator()
+    }
+
+    @Test(expected = None::class)
+    fun `add() with unique qualifiers does not throw exception`() {
+        validator.add(StringQualifier("1"))
+        validator.add(StringQualifier("2"))
+    }
+
+    @Test(expected = DuplicateEffectScopeException::class)
+    fun `add() with duplicated qualifiers throws exception`() {
+        validator.add(StringQualifier("1"))
+        validator.add(StringQualifier("2"))
+        validator.add(StringQualifier("1"))
+    }
+
+    @Test
+    fun `registerEffectScopeValidator() provides Validator instance as singleton`() {
+        val koinApplication = koinApplication {
+            registerEffectScopeValidator()
+        }
+
+        val validator1 = koinApplication.koin.get<EffectScopeValidator>()
+        val validator2 = koinApplication.koin.get<EffectScopeValidator>()
+
+        assertSame(validator1, validator2)
+    }
+
+    @Test(expected = None::class)
+    fun `validateEffectScopeQualifier() validates qualifier during initialization`() {
+        val module = module {
+            validateEffectScopeQualifier(StringQualifier("1"), 0)
+            validateEffectScopeQualifier(StringQualifier("2"), 1)
+        }
+        koinApplication {
+            registerEffectScopeValidator()
+            modules(module)
+        }
+    }
+
+    @Test
+    fun `validateEffectScopeQualifier() with duplicated qualifiers fails during initialization`() {
+        val module = module {
+            validateEffectScopeQualifier(StringQualifier("1"), 0)
+            validateEffectScopeQualifier(StringQualifier("2"), 1)
+            validateEffectScopeQualifier(StringQualifier("1"), 1)
+        }
+        val exception = runCatching {
+            koinApplication {
+                registerEffectScopeValidator()
+                modules(module)
+            }
+        }.exceptionOrNull()
+
+        assertTrue(exception?.cause is DuplicateEffectScopeException)
+    }
+
+    @Test
+    fun `validateEffectScopeQualifier() registers qualified validator`() {
+        val qualifier = StringQualifier("test")
+        val id = 123
+        val module = module {
+            validateEffectScopeQualifier(qualifier, 123)
+        }
+        val koinApplication = koinApplication {
+            registerEffectScopeValidator()
+            modules(module)
+        }
+
+        val validator1 = koinApplication.koin.get<EffectScopeValidator>(named("effectScope-$qualifier-$id"))
+        val validator2 = koinApplication.koin.get<EffectScopeValidator>(named("effectScope-$qualifier-$id"))
+
+        assertSame(validator1, validator2)
+    }
+
+}

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/internal/InstanceFactoryInterceptorIntegrationTest.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/internal/InstanceFactoryInterceptorIntegrationTest.kt
@@ -1,0 +1,104 @@
+package com.uandcode.effects.koin.internal
+
+import androidx.lifecycle.ViewModel
+import com.uandcode.effects.core.EffectProxyMarker
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+
+class InstanceFactoryInterceptorIntegrationTest {
+
+    @Test
+    fun `verify ViewModel closes effects`() {
+        val stack = ConstructorArgStack()
+        val module = module {
+            factoryOf(::EffectViewModel)
+            factoryOf(::EffectProxyMarkerImpl)
+        }
+        val koin = koinApplication {
+            modules(module)
+            overrideInstances(stack)
+        }.koin
+
+        val viewModel = koin.get<EffectViewModel>()
+
+        assertFalse(viewModel.effect.isClosed)
+        viewModel.getCloseable<AutoCloseable>("com.uandcode.effects.koin.closeable")?.close()
+        assertTrue(viewModel.effect.isClosed)
+        assertEquals(0, stack.count())
+    }
+
+    @Test
+    fun `verify ViewModel with indirect instantiation closes effects`() {
+        val stack = ConstructorArgStack()
+        val module = module {
+            factoryOf(::EffectViewModel)
+            factoryOf(::EffectProxyMarkerImpl)
+            factoryOf(::ViewModelBox)
+        }
+        val koin = koinApplication {
+            modules(module)
+            overrideInstances(stack)
+        }.koin
+
+        val viewModelBox = koin.get<ViewModelBox>()
+        val viewModel = viewModelBox.viewModel
+
+        assertFalse(viewModel.effect.isClosed)
+        viewModel.getCloseable<AutoCloseable>("com.uandcode.effects.koin.closeable")?.close()
+        assertTrue(viewModel.effect.isClosed)
+        assertEquals(0, stack.count())
+    }
+
+    @Test
+    fun `verify ViewModel closes effects from other classes`() {
+        val stack = ConstructorArgStack()
+        val module = module {
+            factoryOf(::IndirectEffectViewModel)
+            factoryOf(::EffectProxyMarkerImpl)
+            factoryOf(::EffectBox)
+        }
+        val koin = koinApplication {
+            modules(module)
+            overrideInstances(stack)
+        }.koin
+
+        val viewModel = koin.get<IndirectEffectViewModel>()
+        val effect = viewModel.effectBox.effect
+
+        assertFalse(effect.isClosed)
+        viewModel.getCloseable<AutoCloseable>("com.uandcode.effects.koin.closeable")?.close()
+        assertTrue(effect.isClosed)
+        assertEquals(0, stack.count())
+    }
+
+    private interface Effect
+
+    private class EffectProxyMarkerImpl : Effect, EffectProxyMarker {
+        var isClosed = false
+        override fun close() {
+            isClosed = true
+        }
+    }
+
+    private class EffectViewModel(
+        val effect: EffectProxyMarkerImpl,
+    ) : ViewModel(), Effect
+
+    private class ViewModelBox(
+        val viewModel: EffectViewModel
+    )
+
+    private class EffectBox(
+        val effect: EffectProxyMarkerImpl
+    )
+
+    private class IndirectEffectViewModel(
+        val effectBox: EffectBox,
+    ) : ViewModel(), Effect
+
+}

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/internal/InstanceFactoryInterceptorTest.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/internal/InstanceFactoryInterceptorTest.kt
@@ -1,0 +1,136 @@
+package com.uandcode.effects.koin.internal
+
+import androidx.lifecycle.ViewModel
+import com.uandcode.effects.core.EffectProxyMarker
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.koin.core.definition.BeanDefinition
+import org.koin.core.instance.InstanceFactory
+import org.koin.core.instance.ResolutionContext
+import org.koin.core.scope.Scope
+
+class InstanceFactoryInterceptorTest {
+
+    private lateinit var constructorArgStack: ConstructorArgStack
+
+    @MockK
+    private lateinit var beanDefinition: BeanDefinition<Effect>
+
+    @MockK
+    private lateinit var resolutionContext: ResolutionContext
+
+    @MockK(relaxUnitFun = true)
+    private lateinit var originFactory: InstanceFactory<Effect>
+
+    private lateinit var factory: InstanceFactoryInterceptor<Effect>
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        constructorArgStack = spyk(ConstructorArgStack())
+        every { originFactory.beanDefinition } returns beanDefinition
+        factory = InstanceFactoryInterceptor(constructorArgStack, originFactory)
+    }
+
+    @Test
+    fun `get() with empty stack records and clears args`() {
+        val expectedInstance = mockk<Effect>()
+        every { originFactory.get(any()) } returns expectedInstance
+
+        val instance = factory.get(resolutionContext)
+
+        val slot = slot<ConstructorArg>()
+        verifyOrder {
+            constructorArgStack.push(capture(slot))
+            originFactory.get(resolutionContext)
+            constructorArgStack.clear()
+        }
+        assertSame(expectedInstance, instance)
+    }
+
+    @Test
+    fun `second get() call is delegated to origin factory `() {
+        val expectedInstance = mockk<Effect>()
+        every { originFactory.get(any()) } returns expectedInstance
+
+        val instance1 = factory.get(resolutionContext)
+        val instance2 = factory.get(resolutionContext)
+
+        val slot = slot<ConstructorArg>()
+        verify(exactly = 1) {
+            constructorArgStack.push(capture(slot))
+            constructorArgStack.clear()
+        }
+        verify(exactly = 2) {
+            originFactory.get(resolutionContext)
+        }
+        assertSame(expectedInstance, instance1)
+        assertSame(expectedInstance, instance2)
+    }
+
+    @Test
+    fun `get() with EffectProxyMarker assigns closeable`() {
+        constructorArgStack.push(ConstructorArg())
+        val expectedInstance = mockk<EffectProxyMarkerImpl>()
+        every { originFactory.get(any()) } returns expectedInstance
+
+        factory.get(resolutionContext)
+
+        assertTrue(constructorArgStack.peek()?.hasCloseable() == true)
+    }
+
+    @Test
+    fun `verify beanDefinition`() {
+        assertSame(beanDefinition, factory.beanDefinition)
+    }
+
+    @Test
+    fun `drop() is delegated to origin`() {
+        val scope = mockk<Scope>()
+
+        factory.drop(scope)
+
+        verify(exactly = 1) {
+            originFactory.drop(refEq(scope))
+        }
+    }
+
+    @Test
+    fun `dropAll() is delegated to origin`() {
+        factory.dropAll()
+
+        verify(exactly = 1) {
+            originFactory.dropAll()
+        }
+    }
+
+    @Test
+    fun `isCreated() is delegated to origin`() {
+        every { originFactory.isCreated(any()) } returns true andThen false
+
+        val trueResult = factory.isCreated(resolutionContext)
+        val falseResult = factory.isCreated(resolutionContext)
+
+        assertTrue(trueResult)
+        assertFalse(falseResult)
+        verify(exactly = 2) {
+            originFactory.isCreated(refEq(resolutionContext))
+        }
+    }
+
+    private interface Effect
+    abstract class EffectProxyMarkerImpl : Effect, EffectProxyMarker
+    abstract class EffectViewModel : ViewModel(), Effect
+}

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/internal/InternalKoinEffectScopesTest.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/internal/InternalKoinEffectScopesTest.kt
@@ -1,0 +1,99 @@
+package com.uandcode.effects.koin.internal
+
+import com.uandcode.effects.core.EffectScope
+import com.uandcode.effects.core.ManagedInterfaces
+import com.uandcode.effects.core.RootEffectScopes
+import com.uandcode.effects.core.getProxy
+import com.uandcode.effects.core.runtime.RuntimeEffectScopes
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.koin.core.qualifier.named
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+
+class InternalKoinEffectScopesTest {
+
+    @Test
+    fun `test internalSetupRootEffects()`() {
+        val module = module {
+            internalSetupRootEffects()
+        }
+        val koin = koinApplication {
+            modules(module)
+        }.koin
+
+        val localQualifier = koin.get<LocalEffectQualifier>()
+        assertEquals(KOIN_EFFECT_ROOT_QUALIFIER.value, localQualifier.value)
+
+        val scopeWithQualifier = koin.get<EffectScope>(KOIN_EFFECT_ROOT_QUALIFIER)
+        assertSame(RootEffectScopes.global, scopeWithQualifier)
+
+        val scope = koin.get<EffectScope>()
+        assertSame(RootEffectScopes.global, scope)
+    }
+
+    @Test
+    fun `test installRootEffects()`() {
+        val koin = koinApplication {
+            installRootEffects()
+        }.koin
+
+        val localQualifier = koin.get<LocalEffectQualifier>()
+        assertEquals(KOIN_EFFECT_ROOT_QUALIFIER.value, localQualifier.value)
+
+        val scopeWithQualifier = koin.get<EffectScope>(KOIN_EFFECT_ROOT_QUALIFIER)
+        assertSame(RootEffectScopes.global, scopeWithQualifier)
+
+        val scope = koin.get<EffectScope>()
+        assertSame(RootEffectScopes.global, scope)
+    }
+
+    @Test
+    fun `test internalSetupScopedEffects`() {
+        val key = "key"
+        val rootEffectScope = RuntimeEffectScopes.createGlobal()
+        val module = module {
+            scope<ScopeClass> {
+                internalSetupScopedEffects(
+                    key = key,
+                    managedInterfaces = ManagedInterfaces.ListOf(Effect1::class, Effect2::class)
+                )
+            }
+        }
+        val koin = koinApplication {
+            modules(module)
+            installRootEffects(rootEffectScope)
+        }.koin
+
+        val scope = koin.createScope<ScopeClass>()
+
+        // assert local qualifier
+        val localEffectQualifier1 = scope.get<LocalEffectQualifier>()
+        val localEffectQualifier2 = scope.get<LocalEffectQualifier>()
+        assertEquals(localEffectQualifier1.value, key)
+        assertSame(localEffectQualifier1, localEffectQualifier2)
+
+        // assert named effect scopes
+        val namedEffectScope1 = scope.get<EffectScope>(named(key))
+        val namedEffectScope2 = scope.get<EffectScope>(named(key))
+        assertNotSame(namedEffectScope1, rootEffectScope)
+        assertSame(namedEffectScope1, namedEffectScope2)
+        val namedResult = runCatching { namedEffectScope1.getProxy<Effect1>() }
+        assertTrue(namedResult.isSuccess)
+
+        // assert effect scopes
+        val effectScope1 = scope.get<EffectScope>(named(key))
+        val effectScope2 = scope.get<EffectScope>(named(key))
+        assertNotSame(effectScope1, rootEffectScope)
+        assertSame(effectScope1, effectScope2)
+        val result = runCatching { effectScope1.getProxy<Effect2>() }
+        assertTrue(result.isSuccess)
+    }
+
+    private interface Effect1
+    private interface Effect2
+    private class ScopeClass
+}

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/lifecycle/KoinEffectDelegateTest.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/lifecycle/KoinEffectDelegateTest.kt
@@ -1,0 +1,80 @@
+package com.uandcode.effects.koin.lifecycle
+
+import androidx.lifecycle.LifecycleOwner
+import com.uandcode.effects.core.BoundEffectController
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+
+class KoinEffectDelegateTest {
+
+    @MockK(relaxUnitFun = true)
+    private lateinit var controller: BoundEffectController<Effect>
+
+    @MockK
+    private lateinit var expectedEffect: Effect
+
+    @MockK
+    private lateinit var lifecycleOwner: LifecycleOwner
+
+    @MockK
+    private lateinit var controllerProvider: () -> BoundEffectController<Effect>
+
+    private lateinit var delegate: KoinEffectDelegateImpl<Effect>
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+
+        every { controllerProvider.invoke() } returns controller
+        every { controller.effectImplementation } returns expectedEffect
+        delegate = KoinEffectDelegateImpl(
+            controllerProvider = controllerProvider
+        )
+    }
+
+    @Test
+    fun `verify lazy initialization`() {
+        verify(exactly = 0) {
+            controllerProvider.invoke()
+        }
+
+        val effect1 by delegate
+        val effect2 by delegate
+
+        assertSame(effect1, effect2)
+        verify(exactly = 1) {
+            controllerProvider.invoke()
+        }
+    }
+
+    @Test
+    fun `getValue() returns effect implementation from controller`() {
+        val effect by delegate
+        assertSame(this.expectedEffect, effect)
+    }
+
+    @Test
+    fun `onStart() starts controller`() {
+        delegate.onStart(lifecycleOwner)
+
+        verify(exactly = 1) {
+            controller.start()
+        }
+    }
+
+    @Test
+    fun `onStop() stops controller`() {
+        delegate.onStop(lifecycleOwner)
+
+        verify(exactly = 1) {
+            controller.stop()
+        }
+    }
+
+    private interface Effect
+}

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/lifecycle/LifecycleOwnerExtensionsTest.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/lifecycle/LifecycleOwnerExtensionsTest.kt
@@ -1,0 +1,146 @@
+package com.uandcode.effects.koin.lifecycle
+
+import com.uandcode.effects.core.EffectController
+import com.uandcode.effects.core.EffectScope
+import com.uandcode.effects.core.getController
+import com.uandcode.effects.core.testing.lifecycle.TestLifecycleOwner
+import com.uandcode.effects.koin.lifecycle.mocks.AndroidScopeComponentLifecycleOwner
+import com.uandcode.effects.koin.lifecycle.mocks.KoinComponentLifecycleOwner
+import com.uandcode.effects.koin.lifecycle.mocks.KoinScopeComponentLifecycleOwner
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.koin.core.Koin
+import org.koin.core.context.GlobalContext
+import org.koin.core.scope.Scope
+
+class LifecycleOwnerExtensionsTest {
+
+    @MockK
+    private lateinit var koin: Koin
+
+    @MockK
+    private lateinit var effectScope: EffectScope
+
+    @MockK
+    private lateinit var koinScope: Scope
+
+    @MockK(relaxUnitFun = true)
+    private lateinit var controller: EffectController<EffectImpl>
+
+    private lateinit var effect: EffectImpl
+
+    @MockK
+    private lateinit var effectProvider: () -> EffectImpl
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        effect = EffectImpl()
+        every { effectProvider.invoke() } returns effect
+        every { koin.get<EffectScope>() } returns effectScope
+        every { koinScope.get<EffectScope>() } returns effectScope
+        every { effectScope.getController<EffectImpl>() } returns controller
+        every { controller.isStarted } returns false
+    }
+
+    @Test
+    fun `verify lazyEffect on common LifecycleOwner`() {
+        try {
+            mockkObject(GlobalContext)
+            every { GlobalContext.get() } returns koin
+
+            val lifecycleOwner = TestLifecycleOwner()
+            val effect by lifecycleOwner.lazyEffect(effectProvider)
+
+            verifyLazyEffect(lifecycleOwner) { effect }
+        } finally {
+            unmockkObject(GlobalContext)
+        }
+    }
+
+    @Test
+    fun `verify lazyEffect on KoinComponent`() {
+        val lifecycleOwner = TestLifecycleOwner()
+        val koinComponent = KoinComponentLifecycleOwner(
+            lifecycleOwner, koin
+        )
+
+        val effect by koinComponent.lazyEffect(effectProvider)
+
+        verifyLazyEffect(lifecycleOwner) { effect }
+    }
+
+    @Test
+    fun `verify lazyEffect on KoinScopeComponent`() {
+        val lifecycleOwner = TestLifecycleOwner()
+        val koinComponent = KoinScopeComponentLifecycleOwner(
+            lifecycleOwner, koin, koinScope,
+        )
+
+        val effect by koinComponent.lazyEffect(effectProvider)
+
+        verifyLazyEffect(lifecycleOwner) { effect }
+        verify(exactly = 1) {
+            koinScope.get<EffectScope>()
+        }
+        verify(exactly = 0) {
+            koin.get<EffectScope>()
+        }
+    }
+
+    @Test
+    fun `verify lazyEffect on AndroidScopeComponent`() {
+        val lifecycleOwner = TestLifecycleOwner()
+        val koinComponent = AndroidScopeComponentLifecycleOwner(
+            lifecycleOwner, koinScope,
+        )
+
+        val effect by koinComponent.lazyEffect(effectProvider)
+
+        verifyLazyEffect(lifecycleOwner) { effect }
+        verify(exactly = 1) {
+            koinScope.get<EffectScope>()
+        }
+        verify(exactly = 0) {
+            koin.get<EffectScope>()
+        }
+    }
+
+    private fun verifyLazyEffect(
+        lifecycleOwner: TestLifecycleOwner,
+        effect: () -> EffectImpl,
+    ) {
+        // verify effect is not created/started yet
+        verify(exactly = 0) {
+            effectProvider.invoke()
+            controller.start(any())
+            controller.stop()
+        }
+        // verify lazy initialization
+        assertSame(effect(), this.effect)
+        assertSame(effect(), this.effect)
+        verify(exactly = 1) {
+            effectProvider.invoke()
+        }
+        // verify starting effect
+        lifecycleOwner.start()
+        verify(exactly = 1) {
+            controller.start(effect())
+        }
+        // verify stopping effect
+        lifecycleOwner.stop()
+        verify(exactly = 1) {
+            controller.stop()
+        }
+    }
+
+    private interface Effect
+    private class EffectImpl : Effect
+}

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/lifecycle/mocks/AndroidScopeComponentLifecycleOwner.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/lifecycle/mocks/AndroidScopeComponentLifecycleOwner.kt
@@ -1,0 +1,16 @@
+package com.uandcode.effects.koin.lifecycle.mocks
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import com.uandcode.effects.core.testing.lifecycle.TestLifecycleOwner
+import io.mockk.mockk
+import org.koin.android.scope.AndroidScopeComponent
+import org.koin.core.Koin
+import org.koin.core.scope.Scope
+
+class AndroidScopeComponentLifecycleOwner(
+    val testLifecycleOwner: TestLifecycleOwner = TestLifecycleOwner(),
+    override val scope: Scope = mockk(),
+) : LifecycleOwner, AndroidScopeComponent {
+    override val lifecycle: Lifecycle get() = testLifecycleOwner
+}

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/lifecycle/mocks/KoinComponentLifecycleOwner.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/lifecycle/mocks/KoinComponentLifecycleOwner.kt
@@ -1,0 +1,16 @@
+package com.uandcode.effects.koin.lifecycle.mocks
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import com.uandcode.effects.core.testing.lifecycle.TestLifecycleOwner
+import io.mockk.mockk
+import org.koin.core.Koin
+import org.koin.core.component.KoinComponent
+
+class KoinComponentLifecycleOwner(
+    val testLifecycleOwner: TestLifecycleOwner = TestLifecycleOwner(),
+    val koinInstance: Koin = mockk()
+) : LifecycleOwner, KoinComponent {
+    override val lifecycle: Lifecycle get() = testLifecycleOwner
+    override fun getKoin(): Koin = koinInstance
+}

--- a/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/lifecycle/mocks/KoinScopeComponentLifecycleOwner.kt
+++ b/effects-koin/essentials/src/test/java/com/uandcode/effects/koin/lifecycle/mocks/KoinScopeComponentLifecycleOwner.kt
@@ -1,0 +1,19 @@
+package com.uandcode.effects.koin.lifecycle.mocks
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import com.uandcode.effects.core.testing.lifecycle.TestLifecycleOwner
+import io.mockk.mockk
+import org.koin.core.Koin
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.KoinScopeComponent
+import org.koin.core.scope.Scope
+
+class KoinScopeComponentLifecycleOwner(
+    val testLifecycleOwner: TestLifecycleOwner = TestLifecycleOwner(),
+    val koinInstance: Koin = mockk(),
+    override val scope: Scope = mockk(),
+) : LifecycleOwner, KoinScopeComponent {
+    override val lifecycle: Lifecycle get() = testLifecycleOwner
+    override fun getKoin(): Koin = koinInstance
+}

--- a/gradle/buildSrcLibs.versions.toml
+++ b/gradle/buildSrcLibs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # version of the project itself
-effectLibraryVersion = "2.0.0-alpha05"
+effectLibraryVersion = "2.0.0"
 # android sdk & jvm versions
 minSdk = "23"
 targetSdk = "35"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ androidxActivity = "1.10.1"
 immutableCollections = "0.3.8"
 koin = "4.0.3"
 composeRuntime = "1.7.3"
-effectsMaven = "2.0.0-alpha05"
+effectsMaven = "2.0.0"
 
 [libraries]
 # example apps


### PR DESCRIPTION
- Fix crash when initializing a runtime configuration for the Koin extension
- Add an option for changing `ProxyEffectFactory` when creating own effect scopes derived from the default empty scope
