### PR TITLE
feat: initialize effect instances produced by initEffect immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,11 +345,11 @@ Installation steps may vary depending on the DI framework you're using.
 
    ```kotlin
    // annotation processor (required):
-   ksp("com.uandcode:effects2-hilt-compiler:2.0.1")
+   ksp("com.uandcode:effects2-hilt-compiler:2.1.0")
    // for projects without Jetpack Compose:
-   implementation("com.uandcode:effects2-hilt:2.0.1")
+   implementation("com.uandcode:effects2-hilt:2.1.0")
    // for projects with Jetpack Compose:
-   implementation("com.uandcode:effects2-hilt-compose:2.0.1")
+   implementation("com.uandcode:effects2-hilt-compose:2.1.0")
    ```
 
 For more details, check out the [single-module Hilt example app](/app-examples/hilt/app-singlemodule).
@@ -362,11 +362,11 @@ For more details, check out the [single-module Hilt example app](/app-examples/h
 
    ```kotlin
    // annotation processor:
-   ksp("com.uandcode:effects2-koin-compiler:2.0.1")
+   ksp("com.uandcode:effects2-koin-compiler:2.1.0")
    // for projects without Jetpack Compose:
-   implementation("com.uandcode:effects2-koin:2.0.1")
+   implementation("com.uandcode:effects2-koin:2.1.0")
    // for projects with Jetpack Compose:
-   implementation("com.uandcode:effects2-koin-compose:2.0.1")
+   implementation("com.uandcode:effects2-koin-compose:2.1.0")
    ```
 
 Check out [single-module Koin example app](/app-examples/koin/app-singlemodule) for more details.
@@ -382,11 +382,11 @@ Check out [single-module Koin example app](/app-examples/koin/app-singlemodule) 
 
    ```kotlin
    // annotation processor:
-   ksp("com.uandcode:effects2-core-compiler:2.0.1")
+   ksp("com.uandcode:effects2-core-compiler:2.1.0")
    // for projects without Jetpack Compose:
-   implementation("com.uandcode:effects2-core-lifecycle:2.0.1")
+   implementation("com.uandcode:effects2-core-lifecycle:2.1.0")
    // for projects with Jetpack Compose:
-   implementation("com.uandcode:effects2-core-compose:2.0.1")
+   implementation("com.uandcode:effects2-core-compose:2.1.0")
    ```
 
 Check out [the single-module No-DI example app](/app-examples/core/app-singlemodule) for a working setup.
@@ -397,19 +397,19 @@ Check out [the single-module No-DI example app](/app-examples/core/app-singlemod
 
   ```kotlin
   // Hilt Integration:
-  ksp("com.uandcode:effects2-hilt-compiler:2.0.1")
-  implementation("com.uandcode:effects2-hilt:2.0.1") // without Jetpack Compose
-  implementation("com.uandcode:effects2-hilt-compose:2.0.1") // with Jetpack Compose
+  ksp("com.uandcode:effects2-hilt-compiler:2.1.0")
+  implementation("com.uandcode:effects2-hilt:2.1.0") // without Jetpack Compose
+  implementation("com.uandcode:effects2-hilt-compose:2.1.0") // with Jetpack Compose
   
   // Koin Integration:
-  ksp("com.uandcode:effects2-koin-compiler:2.0.1")
-  implementation("com.uandcode:effects2-koin:2.0.1") // without Jetpack Compose
-  implementation("com.uandcode:effects2-koin-compose:2.0.1") // with Jetpack Compose
+  ksp("com.uandcode:effects2-koin-compiler:2.1.0")
+  implementation("com.uandcode:effects2-koin:2.1.0") // without Jetpack Compose
+  implementation("com.uandcode:effects2-koin-compose:2.1.0") // with Jetpack Compose
   
   // No DI:
-  ksp("com.uandcode:effects2-core-compiler:2.0.1")
-  implementation("com.uandcode:effects2-core-lifecycle:2.0.1") // without Jetpack Compose
-  implementation("com.uandcode:effects2-core-compose:2.0.1") // with Jetpack Compose
+  ksp("com.uandcode:effects2-core-compiler:2.1.0")
+  implementation("com.uandcode:effects2-core-lifecycle:2.1.0") // without Jetpack Compose
+  implementation("com.uandcode:effects2-core-compose:2.1.0") // with Jetpack Compose
   ```
 
 - Additional configuration is required for your __Library__ modules, if you
@@ -444,9 +444,9 @@ so this guide is relevant only for projects using Hilt.
 1. In your `build.gradle` file, update the library dependencies:
 
    ```kotlin
-   ksp("com.uandcode:effects2-hilt-compiler:2.0.1")
-   implementation("com.uandcode:effects2-hilt:2.0.1") // without Jetpack Compose
-   implementation("com.uandcode:effects2-hilt-compose:2.0.1") // with Jetpack Compose
+   ksp("com.uandcode:effects2-hilt-compiler:2.1.0")
+   implementation("com.uandcode:effects2-hilt:2.1.0") // without Jetpack Compose
+   implementation("com.uandcode:effects2-hilt-compose:2.1.0") // with Jetpack Compose
    ```
 
 2. Update relevant import statements and package references:

--- a/docs/effects-and-hilt.md
+++ b/docs/effects-and-hilt.md
@@ -27,11 +27,11 @@ This page describes how to install and use the library with Hilt DI Framework.
 
    ```kotlin
    // annotation processor (required):
-   ksp("com.uandcode:effects2-hilt-compiler:2.0.1")
+   ksp("com.uandcode:effects2-hilt-compiler:2.1.0")
    // for projects without Jetpack Compose:
-   implementation("com.uandcode:effects2-hilt:2.0.1")
+   implementation("com.uandcode:effects2-hilt:2.1.0")
    // for projects with Jetpack Compose:
-   implementation("com.uandcode:effects2-hilt-compose:2.0.1")
+   implementation("com.uandcode:effects2-hilt-compose:2.1.0")
    ```
 
 For more details, check out the [single-module Hilt example app](/app-examples/hilt/app-singlemodule).
@@ -41,9 +41,9 @@ For more details, check out the [single-module Hilt example app](/app-examples/h
 - Dependencies for your __application module__ remain the same:
 
   ```kotlin
-  ksp("com.uandcode:effects2-hilt-compiler:2.0.1")
-  implementation("com.uandcode:effects2-hilt:2.0.1") // without Jetpack Compose
-  implementation("com.uandcode:effects2-hilt-compose:2.0.1") // with Jetpack Compose
+  ksp("com.uandcode:effects2-hilt-compiler:2.1.0")
+  implementation("com.uandcode:effects2-hilt:2.1.0") // without Jetpack Compose
+  implementation("com.uandcode:effects2-hilt-compose:2.1.0") // with Jetpack Compose
   ```
 
 - Additional configuration is required for your __Library__ modules, if you
@@ -72,9 +72,9 @@ and imports. Please make sure to update your project accordingly.
 1. In your `build.gradle` file, update the library dependencies:
 
    ```kotlin
-   ksp("com.uandcode:effects2-hilt-compiler:2.0.1")
-   implementation("com.uandcode:effects2-hilt:2.0.1") // without Jetpack Compose
-   implementation("com.uandcode:effects2-hilt-compose:2.0.1") // with Jetpack Compose
+   ksp("com.uandcode:effects2-hilt-compiler:2.1.0")
+   implementation("com.uandcode:effects2-hilt:2.1.0") // without Jetpack Compose
+   implementation("com.uandcode:effects2-hilt-compose:2.1.0") // with Jetpack Compose
    ```
 
 2. Update relevant import statements and package references:

--- a/docs/effects-and-koin.md
+++ b/docs/effects-and-koin.md
@@ -31,11 +31,11 @@ This page explains how to install and use the library with the Koin DI Framework
 
    ```kotlin
    // annotation processor:
-   ksp("com.uandcode:effects2-koin-compiler:2.0.1")
+   ksp("com.uandcode:effects2-koin-compiler:2.1.0")
    // for projects without Jetpack Compose:
-   implementation("com.uandcode:effects2-koin:2.0.1")
+   implementation("com.uandcode:effects2-koin:2.1.0")
    // for projects with Jetpack Compose:
-   implementation("com.uandcode:effects2-koin-compose:2.0.1")
+   implementation("com.uandcode:effects2-koin-compose:2.1.0")
    
    // Koin dependencies
    implementation("io.insert-koin:koin-android:4.0.3")
@@ -50,9 +50,9 @@ For more details, check out the [single-module Koin example app](/app-examples/k
 - Dependencies for your __application module__ remain the same:
 
   ```kotlin
-  ksp("com.uandcode:effects2-koin-compiler:2.0.1")
-  implementation("com.uandcode:effects2-koin:2.0.1") // without Jetpack Compose
-  implementation("com.uandcode:effects2-koin-compose:2.0.1") // with Jetpack Compose
+  ksp("com.uandcode:effects2-koin-compiler:2.1.0")
+  implementation("com.uandcode:effects2-koin:2.1.0") // without Jetpack Compose
+  implementation("com.uandcode:effects2-koin-compose:2.1.0") // with Jetpack Compose
   ```
 
 - Additional configuration is required for your __Library__ modules, if you

--- a/docs/effects-pure.md
+++ b/docs/effects-pure.md
@@ -28,11 +28,11 @@ Add the necessary dependencies:
 
 ```kotlin
 // annotation processor:
-ksp("com.uandcode:effects2-core-compiler:2.0.1")
+ksp("com.uandcode:effects2-core-compiler:2.1.0")
 // for projects without Jetpack Compose:
-implementation("com.uandcode:effects2-core-lifecycle:2.0.1")
+implementation("com.uandcode:effects2-core-lifecycle:2.1.0")
 // for projects with Jetpack Compose:
-implementation("com.uandcode:effects2-core-compose:2.0.1")
+implementation("com.uandcode:effects2-core-compose:2.1.0")
 ```
 
 Check out [the single-module No-DI example app](/app-examples/core/app-singlemodule) for a working setup.
@@ -42,9 +42,9 @@ Check out [the single-module No-DI example app](/app-examples/core/app-singlemod
 - Dependencies for your __application module__ remain the same:
 
   ```kotlin
-  ksp("com.uandcode:effects2-core-compiler:2.0.1")
-  implementation("com.uandcode:effects2-core-lifecycle:2.0.1") // without Jetpack Compose
-  implementation("com.uandcode:effects2-core-compose:2.0.1") // with Jetpack Compose
+  ksp("com.uandcode:effects2-core-compiler:2.1.0")
+  implementation("com.uandcode:effects2-core-lifecycle:2.1.0") // without Jetpack Compose
+  implementation("com.uandcode:effects2-core-compose:2.1.0") // with Jetpack Compose
   ```
 
 - Additional configuration is required for your __Library__ modules, if you

--- a/docs/ksp-and-koin-installation.md
+++ b/docs/ksp-and-koin-installation.md
@@ -57,6 +57,6 @@ even [without KSP](no-ksp-installation.md), with a bit of additional configurati
    dependencies {
        // KSP annotation processors should be added using the 'ksp' configuration
        // Example: adding Effect's KSP compiler
-       // ksp("com.uandcode:effects2-koin-compiler:2.0.1")
+       // ksp("com.uandcode:effects2-koin-compiler:2.1.0")
    }
    ```

--- a/docs/no-ksp-installation.md
+++ b/docs/no-ksp-installation.md
@@ -40,11 +40,11 @@ You can skip KSP if:
 
    ```kotlin
    // required:
-   implementation("com.uandcode:effects2-core-runtime:2.0.1")
+   implementation("com.uandcode:effects2-core-runtime:2.1.0")
    // for projects without Jetpack Compose:
-   implementation("com.uandcode:effects2-koin:2.0.1")
+   implementation("com.uandcode:effects2-koin:2.1.0")
    // for projects with Jetpack Compose:
-   implementation("com.uandcode:effects2-koin-compose:2.0.1")
+   implementation("com.uandcode:effects2-koin-compose:2.1.0")
    
    // Koin dependencies:
    implementation("io.insert-koin:koin-core:4.0.3") // core
@@ -174,11 +174,11 @@ You can skip KSP if:
 
    ```kotlin
    // required:
-   implementation("com.uandcode:effects2-core-runtime:2.0.1")
+   implementation("com.uandcode:effects2-core-runtime:2.1.0")
    // for projects without Jetpack Compose:
-   implementation("com.uandcode:effects2-core-lifecycle:2.0.1")
+   implementation("com.uandcode:effects2-core-lifecycle:2.1.0")
    // for projects with Jetpack Compose:
-   implementation("com.uandcode:effects2-core-compose:2.0.1")   
+   implementation("com.uandcode:effects2-core-compose:2.1.0")   
    ```
 
 2. Create a custom Application class and call `setupRuntimeEffectsGlobally()`

--- a/effects-core/lifecycle/src/main/java/com/uandcode/effects/core/lifecycle/LifecycleOwnerExtensions.kt
+++ b/effects-core/lifecycle/src/main/java/com/uandcode/effects/core/lifecycle/LifecycleOwnerExtensions.kt
@@ -105,5 +105,6 @@ public inline fun <reified T : Any> LifecycleOwner.initEffect(
     scope: EffectScope = RootEffectScopes.global,
     noinline effectProvider: () -> T
 ) {
-    lazyEffect(scope, effectProvider)
+    val effect by lazyEffect(scope, effectProvider)
+    effect // access effect instance immediately to create it
 }

--- a/effects-hilt/essentials/src/main/java/com/uandcode/effects/hilt/HiltLifecycleOwnerExtensions.kt
+++ b/effects-hilt/essentials/src/main/java/com/uandcode/effects/hilt/HiltLifecycleOwnerExtensions.kt
@@ -147,7 +147,8 @@ public inline fun <reified T : Any> Fragment.lazyEffect(
 public inline fun <reified T : Any> ComponentActivity.initEffect(
     noinline effectProvider: () -> T
 ) {
-    lazyEffect(effectProvider)
+    val effect by lazyEffect(effectProvider)
+    effect // access effect instance immediately to create it
 }
 
 /**
@@ -195,7 +196,8 @@ public inline fun <reified T : Any> ComponentActivity.initEffect(
 public inline fun <reified T : Any> Fragment.initEffect(
     noinline effectProvider: () -> T
 ) {
-    lazyEffect(effectProvider)
+    val effect by lazyEffect(effectProvider)
+    effect // access effect instance immediately to create it
 }
 
 @PublishedApi

--- a/effects-koin/essentials/src/main/java/com/uandcode/effects/koin/lifecycle/LifecycleOwnerExtensions.kt
+++ b/effects-koin/essentials/src/main/java/com/uandcode/effects/koin/lifecycle/LifecycleOwnerExtensions.kt
@@ -108,5 +108,6 @@ public inline fun <reified T : Any> LifecycleOwner.lazyEffect(
 public inline fun <reified T : Any> LifecycleOwner.initEffect(
     noinline effectProvider: () -> T
 ) {
-    lazyEffect(effectProvider)
+    val effect by lazyEffect(effectProvider)
+    effect // access effect instance immediately to create it
 }

--- a/gradle/buildSrcLibs.versions.toml
+++ b/gradle/buildSrcLibs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # version of the project itself
-effectLibraryVersion = "2.0.1"
+effectLibraryVersion = "2.1.0"
 # android sdk & jvm versions
 minSdk = "23"
 targetSdk = "36"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ androidxActivity = "1.12.4"
 immutableCollections = "0.4.0"
 koin = "4.1.1"
 composeRuntime = "1.10.1"
-effectsMaven = "2.0.1"
+effectsMaven = "2.1.0"
 
 [libraries]
 # example apps


### PR DESCRIPTION
The `initEffect` call is intended to be invoked from lifecycle callbacks (e.g., `onCreate`), so that the resulting effect can be instantiated immediately.